### PR TITLE
feat: update droplet installation flow to handle reinstalls

### DIFF
--- a/app/clients/fluid_client.rb
+++ b/app/clients/fluid_client.rb
@@ -1,6 +1,7 @@
 class FluidClient
   include HTTParty
   include Fluid::Droplets
+  include Fluid::Webhooks
 
   base_uri Setting.fluid_api.base_url
   headers "Authorization" => "Bearer #{Setting.fluid_api.api_key}", "Content-Type" => "application/json"

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -20,7 +20,7 @@ class WebhooksController < ApplicationController
 private
 
   def droplet_installed_for_first_time?
-    params[:resource] == "company_droplet" && params[:event] == "created"
+    params[:resource] == "droplet" && params[:event] == "installed"
   end
 
   def authenticate_webhook_token

--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -16,15 +16,16 @@ class DropletInstalledJob < WebhookEventJob
     validate_payload_keys("company")
     company_attributes = get_payload.fetch("company", {})
 
-    company = Company.new(company_attributes.slice(
+    company = Company.find_by(fluid_shop: company_attributes["fluid_shop"]) || Company.new
+    company.assign_attributes(company_attributes.slice(
       "fluid_shop",
       "name",
       "fluid_company_id",
-      "company_droplet_uuid",
       "authentication_token",
       "webhook_verification_token",
+      "droplet_installation_uuid"
     ))
-
+    company.company_droplet_uuid = company_attributes.fetch("droplet_uuid")
     company.active = true
 
     unless company.save

--- a/config/initializers/event_handler.rb
+++ b/config/initializers/event_handler.rb
@@ -7,7 +7,7 @@
 # It also runs on every code reload in development, ensuring the handlers
 # are always registered.
 Rails.application.config.to_prepare do
-  EventHandler.register_handler("company_droplet.created", DropletInstalledJob)
-  EventHandler.register_handler("company_droplet.uninstalled", DropletUninstalledJob)
-  EventHandler.register_handler("company_droplet.installed", DropletReinstalledJob)
+  # EventHandler.register_handler("company_droplet.created", DropletInstalledJob)
+  EventHandler.register_handler("droplet.uninstalled", DropletUninstalledJob)
+  EventHandler.register_handler("droplet.installed", DropletInstalledJob)
 end


### PR DESCRIPTION
Improve droplet installation handling

This PR addresses a few issues we found with droplet installations:

- Webhook event names didn't match the API
- Missing webhooks module in the client
- UUID fields weren't being mapped correctly

The changes ensure we handle both new installations and reinstalls properly.

[DRO-4/update-droplet-template-repository](https://linear.app/fluid-commerce/issue/DRO-4/update-droplet-template-repository)