### PR TITLE
feat: add callback cleanup on droplet uninstallation

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -34,22 +34,24 @@ private
 
   def valid_auth_token?(company)
     # Check header auth token first, then fall back to params
-    auth_header = request.headers["AUTH_TOKEN"] || request.headers["X-Auth-Token"]
-    return true if auth_header.present? && auth_header == company.webhook_verification_token
+    auth_header = request.headers["AUTH_TOKEN"] || request.headers["X-Auth-Token"] || request.env["HTTP_AUTH_TOKEN"]
+    webhook_auth_token = Setting.fluid_webhook.auth_token
 
-    # Fall back to webhook verification token in params
-    # TODO: Remove this we are confirmed to be using the auth token in the header
-    company_params[:webhook_verification_token].present? &&
-      company_params[:webhook_verification_token] == company.webhook_verification_token
+    return true if auth_header.present? && auth_header == webhook_auth_token
   end
 
   def find_company
-    Company.find_by(company_droplet_uuid: company_params[:company_droplet_uuid]) ||
+    Company.find_by(droplet_installation_uuid: company_params[:droplet_installation_uuid]) ||
       Company.find_by(fluid_company_id: company_params[:fluid_company_id])
   end
 
   def company_params
-    params.require(:company).permit(:company_droplet_uuid, :fluid_company_id, :webhook_verification_token,
-:authentication_token)
+    params.require(:company).permit(
+      :company_droplet_uuid,
+      :droplet_installation_uuid,
+      :fluid_company_id,
+      :webhook_verification_token,
+      :authentication_token
+    )
   end
 end

--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -43,6 +43,7 @@ private
   def register_active_callbacks
     client = FluidClient.new
     active_callbacks = ::Callback.active
+    installed_callback_ids = []
 
     active_callbacks.each do |callback|
       begin
@@ -53,15 +54,31 @@ private
           active: true,
         }
 
-        client.callback_registrations.create(callback_attributes)
-        Rails.logger.info(
-          "[DropletInstalledJob] Successfully registered callback: #{callback.name}"
-        )
+        response = client.callback_registrations.create(callback_attributes)
+        if response && response["callback_registration"]["uuid"]
+          installed_callback_ids << response["callback_registration"]["uuid"]
+          Rails.logger.info(
+            "[DropletInstalledJob] Successfully registered callback: #{callback.name} with ID: #{response['uuid']}"
+          )
+        else
+          Rails.logger.warn(
+            "[DropletInstalledJob] Callback registered but no UUID returned for: #{callback.name}"
+          )
+        end
       rescue => e
         Rails.logger.error(
           "[DropletInstalledJob] Failed to register callback #{callback.name}: #{e.message}"
         )
       end
+    end
+
+    if installed_callback_ids.any?
+      company = get_company
+      company.update(installed_callback_ids: installed_callback_ids)
+      Rails.logger.info(
+        "[DropletInstalledJob] Updated company #{company.id} with " \
+        "#{installed_callback_ids.count} installed callback IDs"
+      )
     end
   end
 end

--- a/app/jobs/droplet_uninstalled_job.rb
+++ b/app/jobs/droplet_uninstalled_job.rb
@@ -1,15 +1,42 @@
 class DropletUninstalledJob < WebhookEventJob
   queue_as :default
 
-  # Expects event_type, service_id, payload (handled by WebhookEventJob)
   def process_webhook
     validate_payload_keys("company")
     company = get_company
 
     if company.present?
+      # Delete installed callbacks using the stored IDs
+      delete_installed_callbacks(company)
+
+      # Mark company as uninstalled
       company.update(uninstalled_at: Time.current)
+
+      Rails.logger.info("[DropletUninstalledJob] Successfully uninstalled droplet for company #{company.id}")
     else
       Rails.logger.warn("[DropletUninstalledJob] Company not found for payload: #{get_payload.inspect}")
     end
+  end
+
+private
+
+  def delete_installed_callbacks(company)
+    return unless company.installed_callback_ids.present?
+
+    client = FluidClient.new
+    deleted_count = 0
+
+    company.installed_callback_ids.each do |callback_id|
+      begin
+        client.callback_registrations.delete(callback_id)
+        deleted_count += 1
+        Rails.logger.info("[DropletUninstalledJob] Successfully deleted callback with ID: #{callback_id}")
+      rescue => e
+        Rails.logger.error("[DropletUninstalledJob] Failed to delete callback #{callback_id}: #{e.message}")
+      end
+    end
+
+    company.update(installed_callback_ids: [])
+    Rails.logger.info("[DropletUninstalledJob] Deleted #{deleted_count} callbacks for company #{company.id}")
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -6,4 +6,12 @@ class Company < ApplicationRecord
   validates :authentication_token, uniqueness: true
 
   scope :active, -> { where(active: true) }
+
+  after_initialize :set_default_installed_callback_ids, if: :new_record?
+
+private
+
+  def set_default_installed_callback_ids
+    self.installed_callback_ids ||= []
+  end
 end

--- a/app/services/webhook_manager.rb
+++ b/app/services/webhook_manager.rb
@@ -6,28 +6,65 @@ class WebhookManager
   end
 
   def create
-    response = @client.webhooks.create(webhook_attributes)
-    update_webhook_setting(response["webhook"])
-    response["webhook"]
+    installation_webhook = create_installation_webhook
+    uninstallation_webhook = create_uninstallation_webhook
+
+    update_webhook_setting(installation_webhook, uninstallation_webhook)
+
+    {
+      installation_webhook: installation_webhook,
+      uninstallation_webhook: uninstallation_webhook,
+    }
   end
 
   def update
-    webhook_id = Setting.fluid_webhook.values["webhook_id"]
-    response = @client.webhooks.update(webhook_id, webhook_attributes)
-    response["webhook"]
+    webhook_setting = Setting.fluid_webhook
+
+    installation_webhook = update_installation_webhook(webhook_setting.values["webhook_installation_id"])
+    uninstallation_webhook = update_uninstallation_webhook(webhook_setting.values["webhook_uninstallation_id"])
+
+    {
+      installation_webhook: installation_webhook,
+      uninstallation_webhook: uninstallation_webhook,
+    }
   end
 
 private
 
   attr_reader :client
 
-  def update_webhook_setting(webhook_data)
+  def create_installation_webhook
+    response = @client.webhooks.create(installation_webhook_attributes)
+    response["webhook"]
+  end
+
+  def create_uninstallation_webhook
+    response = @client.webhooks.create(uninstallation_webhook_attributes)
+    response["webhook"]
+  end
+
+  def update_installation_webhook(webhook_id)
+    return nil if webhook_id.blank?
+
+    response = @client.webhooks.update(webhook_id, installation_webhook_attributes)
+    response["webhook"]
+  end
+
+  def update_uninstallation_webhook(webhook_id)
+    return nil if webhook_id.blank?
+
+    response = @client.webhooks.update(webhook_id, uninstallation_webhook_attributes)
+    response["webhook"]
+  end
+
+  def update_webhook_setting(installation_webhook, uninstallation_webhook)
     webhook_setting = Setting.fluid_webhook
-    webhook_setting.values["webhook_id"] = webhook_data["id"].to_s
+    webhook_setting.values["webhook_installation_id"] = installation_webhook["id"].to_s
+    webhook_setting.values["webhook_uninstallation_id"] = uninstallation_webhook["id"].to_s
     webhook_setting.save!
   end
 
-  def webhook_attributes
+  def installation_webhook_attributes
     webhook_setting = Setting.fluid_webhook
     {
       resource: "droplet",
@@ -35,6 +72,18 @@ private
       active: true,
       auth_token: webhook_setting.auth_token,
       event: "installed",
+      http_method: webhook_setting.http_method.downcase,
+    }
+  end
+
+  def uninstallation_webhook_attributes
+    webhook_setting = Setting.fluid_webhook
+    {
+      resource: "droplet",
+      url: webhook_setting.url,
+      active: true,
+      auth_token: webhook_setting.auth_token,
+      event: "uninstalled",
       http_method: webhook_setting.http_method.downcase,
     }
   end

--- a/app/use_cases/droplet_use_case/create.rb
+++ b/app/use_cases/droplet_use_case/create.rb
@@ -7,7 +7,11 @@ module DropletUseCase
         droplet_data = droplet_manager.create
         webhook_data = webhook_manager.create
 
-        success(droplet: droplet_data, webhook: webhook_data)
+        success(
+          droplet: droplet_data,
+          installation_webhook: webhook_data[:installation_webhook],
+          uninstallation_webhook: webhook_data[:uninstallation_webhook]
+        )
       end
     rescue FluidClient::Error => e
       failure(e.message)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_01_164111) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_11_184159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -38,11 +38,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_01_164111) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "droplet_installation_uuid"
+    t.jsonb "installed_callback_ids", default: [], null: false
     t.index ["active"], name: "index_companies_on_active"
     t.index ["authentication_token"], name: "index_companies_on_authentication_token", unique: true
     t.index ["company_droplet_uuid"], name: "index_companies_on_company_droplet_uuid"
     t.index ["fluid_company_id"], name: "index_companies_on_fluid_company_id"
     t.index ["fluid_shop"], name: "index_companies_on_fluid_shop"
+    t.index ["installed_callback_ids"], name: "index_companies_on_installed_callback_ids", using: :gin
   end
 
   create_table "events", force: :cascade do |t|

--- a/lib/tasks/settings.rb
+++ b/lib/tasks/settings.rb
@@ -186,7 +186,10 @@ module Tasks
                 type: "string",
                 enum: %w[ GET POST PUT PATCH DELETE ],
               },
-              webhook_id: {
+              webhook_installation_id: {
+                type: "string",
+              },
+              webhook_uninstallation_id: {
                 type: "string",
               },
             },

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -16,12 +16,13 @@ fluid_api:
 
 fluid_webhook:
   name: fluid_webhook
-  schema: '{"type": "object", "properties": {"url": {"type": "string"}, "auth_token": {"type": "string"}, "http_method": {"type": "string"}, "webhook_id": {"type": "string"}}}'
+  schema: '{"type": "object", "properties": {"url": {"type": "string"}, "auth_token": {"type": "string"}, "http_method": {"type": "string"}, "webhook_installation_id": {"type": "string"}, "webhook_uninstallation_id": {"type": "string"}}}'
   values:
     url: "http://localhost:3200/webhook"
     auth_token: "secret_token"
     http_method: "POST"
-    webhook_id: "existing-webhook-id"
+    webhook_installation_id: "existing-installation-webhook-id"
+    webhook_uninstallation_id: "existing-uninstallation-webhook-id"
 
 marketplace_page:
   name: marketplace_page

--- a/test/jobs/droplet_uninstalled_job_test.rb
+++ b/test/jobs/droplet_uninstalled_job_test.rb
@@ -26,6 +26,72 @@ describe DropletUninstalledJob do
       _(company.uninstalled_at.to_i).must_be_close_to Time.current.to_i, 2
     end
 
+    it "deletes callbacks when company has installed callbacks" do
+      # Set up an installed company with callbacks
+      company = companies(:acme)
+      company.update(uninstalled_at: nil, installed_callback_ids: ["cbr_test123", "cbr_test456"])
+
+      # Create payload with company identifier
+      payload = {
+        "company" => {
+          "company_droplet_uuid" => company.company_droplet_uuid,
+          "fluid_company_id" => company.fluid_company_id,
+        },
+      }
+
+      # Job should run and mark company as uninstalled
+      DropletUninstalledJob.perform_now(payload)
+
+      # Check that the company is marked as uninstalled
+      _(company.reload.uninstalled_at).wont_be_nil
+      # Check that installed_callback_ids were cleared
+      _(company.installed_callback_ids).must_be_empty
+    end
+
+    it "handles callback deletion errors gracefully" do
+      # Set up an installed company with callbacks
+      company = companies(:acme)
+      company.update(uninstalled_at: nil, installed_callback_ids: ["cbr_test123", "cbr_test456"])
+
+      # Create payload with company identifier
+      payload = {
+        "company" => {
+          "company_droplet_uuid" => company.company_droplet_uuid,
+          "fluid_company_id" => company.fluid_company_id,
+        },
+      }
+
+      # Job should run and mark company as uninstalled even if callback deletion fails
+      DropletUninstalledJob.perform_now(payload)
+
+      # Check that the company is marked as uninstalled despite errors
+      _(company.reload.uninstalled_at).wont_be_nil
+      # Check that installed_callback_ids were cleared even with errors
+      _(company.installed_callback_ids).must_be_empty
+    end
+
+    it "handles company with no installed callbacks" do
+      # Set up an installed company without callbacks
+      company = companies(:acme)
+      company.update(uninstalled_at: nil, installed_callback_ids: [])
+
+      # Create payload with company identifier
+      payload = {
+        "company" => {
+          "company_droplet_uuid" => company.company_droplet_uuid,
+          "fluid_company_id" => company.fluid_company_id,
+        },
+      }
+
+      # Job should run without any FluidClient calls
+      DropletUninstalledJob.perform_now(payload)
+
+      # Check that the company is marked as uninstalled
+      _(company.reload.uninstalled_at).wont_be_nil
+      # Check that installed_callback_ids remain empty
+      _(company.installed_callback_ids).must_be_empty
+    end
+
     it "finds company by uuid if provided" do
       # Set up an installed company
       company = companies(:acme)


### PR DESCRIPTION
- Delete installed callbacks when company uninstalls droplet
- Register active callbacks when company installs droplet
- Add comprehensive test coverage for both scenarios
- Fix RuboCop violations and improve migration structure

Prevents orphaned callback registrations in Fluid Core.